### PR TITLE
improve ergonomics of CommandDefinitionBuilder

### DIFF
--- a/.github/workflows/build_debug.yml
+++ b/.github/workflows/build_debug.yml
@@ -20,7 +20,7 @@ jobs:
       - name: fetch dependencies
         run: sh ./cicd/cargo_fetch.sh
       - name: run debug build
-        run: cargo build
+        run: cargo build --all-targets
       - name: run debug tests
         run: cargo test
       - name: build obtain_bim

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: fetch dependencies
         run: sh ./cicd/cargo_fetch.sh
       - name: run release build
-        run: cargo build --release
+        run: cargo build --all-targets --release
       - name: run release tests
         run: cargo test --release
       - name: build obtain_bim

--- a/rocketbot/src/commands.rs
+++ b/rocketbot/src/commands.rs
@@ -324,10 +324,10 @@ mod tests {
     #[test]
     fn test_quoting() {
         let command = CommandDefinitionBuilder::new(
-            "bloop".into(),
-            "bloop".to_owned(),
-            "{cpfx}bloop [STUFF]".to_owned(),
-            "Bloops.".to_owned(),
+            "bloop",
+            "bloop",
+            "{cpfx}bloop [STUFF]",
+            "Bloops.",
         )
             .arg_count(2)
             .build();

--- a/rocketbot_interface/src/commands.rs
+++ b/rocketbot_interface/src/commands.rs
@@ -72,21 +72,26 @@ pub struct CommandDefinitionBuilder {
     definition: CommandDefinition,
 }
 impl CommandDefinitionBuilder {
-    pub fn new(
-        name: String,
-        plugin_name: String,
-        usage: String,
-        description: String,
-    ) -> Self {
+    pub fn new<N, P, U, D>(
+        name: N,
+        plugin_name: P,
+        usage: U,
+        description: D,
+    ) -> Self
+            where
+                N: Into<String>,
+                P: Into<String>,
+                U: Into<String>,
+                D: Into<String> {
         let definition = CommandDefinition::new(
-            name,
-            plugin_name,
+            name.into(),
+            plugin_name.into(),
             Some(HashSet::new()),
             HashMap::new(),
             0,
             CommandBehaviors::empty(),
-            usage,
-            description,
+            usage.into(),
+            description.into(),
         );
         Self {
             definition,
@@ -103,9 +108,9 @@ impl CommandDefinitionBuilder {
         self
     }
 
-    pub fn add_flag(mut self, new_flag: &str) -> Self {
+    pub fn add_flag<N: Into<String>>(mut self, new_flag: N) -> Self {
         if let Some(flags) = &mut self.definition.flags {
-            flags.insert(new_flag.to_owned());
+            flags.insert(new_flag.into());
         }
         self
     }
@@ -115,8 +120,8 @@ impl CommandDefinitionBuilder {
         self
     }
 
-    pub fn add_option(mut self, new_option: &str, new_type: CommandValueType) -> Self {
-        self.definition.options.insert(new_option.to_owned(), new_type);
+    pub fn add_option<N: Into<String>>(mut self, new_option: N, new_type: CommandValueType) -> Self {
+        self.definition.options.insert(new_option.into(), new_type);
         self
     }
 

--- a/rocketbot_plugin_allograph/src/lib.rs
+++ b/rocketbot_plugin_allograph/src/lib.rs
@@ -180,10 +180,10 @@ impl RocketBotPlugin for AllographPlugin {
 
         my_interface.register_private_message_command(
             &CommandDefinitionBuilder::new(
-                "allocool".into(),
-                "allograph".to_owned(),
-                "{cpfx}allocool CHANNEL".to_owned(),
-                "Outputs current Allograph cooldowns in the given channel.".to_owned(),
+                "allocool",
+                "allograph",
+                "{cpfx}allocool CHANNEL",
+                "Outputs current Allograph cooldowns in the given channel.",
             )
                 .build()
         ).await;

--- a/rocketbot_plugin_barcode/src/lib.rs
+++ b/rocketbot_plugin_barcode/src/lib.rs
@@ -353,19 +353,19 @@ impl RocketBotPlugin for BarcodePlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "datamatrix".to_owned(),
-                "barcode".to_owned(),
-                "{cpfx}datamatrix TEXT".to_owned(),
-                "Encodes the given text into a Data Matrix barcode.".to_owned(),
+                "datamatrix",
+                "barcode",
+                "{cpfx}datamatrix TEXT",
+                "Encodes the given text into a Data Matrix barcode.",
             )
                 .build()
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "vaxcert".to_owned(),
-                "barcode".to_owned(),
-                "{cpfx}vaxcert OPTIONS".to_owned(),
-                "Generates a vaccination certificate QR code.".to_owned(),
+                "vaxcert",
+                "barcode",
+                "{cpfx}vaxcert OPTIONS",
+                "Generates a vaccination certificate QR code.",
             )
                 // flags
                 .add_flag("p")

--- a/rocketbot_plugin_bim/src/lib.rs
+++ b/rocketbot_plugin_bim/src/lib.rs
@@ -2459,10 +2459,10 @@ impl RocketBotPlugin for BimPlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "bim".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}bim NUMBER".to_owned(),
-                "Obtains information about the public transport vehicle with the given number.".to_owned(),
+                "bim",
+                "bim",
+                "{cpfx}bim NUMBER",
+                "Obtains information about the public transport vehicle with the given number.",
             )
                 .add_option("company", CommandValueType::String)
                 .add_option("c", CommandValueType::String)
@@ -2470,10 +2470,10 @@ impl RocketBotPlugin for BimPlugin {
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "bimride".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}bimride VEHICLE[+VEHICLE...][/LINE]".to_owned(),
-                "Registers a ride with the given vehicle(s) on the given line.".to_owned(),
+                "bimride",
+                "bim",
+                "{cpfx}bimride VEHICLE[+VEHICLE...][/LINE]",
+                "Registers a ride with the given vehicle(s) on the given line.",
             )
                 .add_option("company", CommandValueType::String)
                 .add_option("c", CommandValueType::String)
@@ -2481,10 +2481,10 @@ impl RocketBotPlugin for BimPlugin {
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "topbims".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}topbims".to_owned(),
-                "Returns the most-ridden vehicle(s).".to_owned(),
+                "topbims",
+                "bim",
+                "{cpfx}topbims",
+                "Returns the most-ridden vehicle(s).",
             )
                 .add_option("company", CommandValueType::String)
                 .add_option("c", CommandValueType::String)
@@ -2493,49 +2493,49 @@ impl RocketBotPlugin for BimPlugin {
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "topriders".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}topriders".to_owned(),
-                "Returns the most active rider(s).".to_owned(),
+                "topriders",
+                "bim",
+                "{cpfx}topriders",
+                "Returns the most active rider(s).",
             )
                 .add_lookback_flags()
                 .build()
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "bimcompanies".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}bimcompanies".to_owned(),
-                "Returns known public-transport operators.".to_owned(),
+                "bimcompanies",
+                "bim",
+                "{cpfx}bimcompanies",
+                "Returns known public-transport operators.",
             )
                 .build()
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "favbims".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}favbims".to_owned(),
-                "Returns each rider's most-ridden vehicle.".to_owned(),
-            )
-                .add_lookback_flags()
-                .build()
-        ).await;
-        my_interface.register_channel_command(
-            &CommandDefinitionBuilder::new(
-                "topbimdays".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}topbimdays".to_owned(),
-                "Returns the days with the most vehicle rides.".to_owned(),
+                "favbims",
+                "bim",
+                "{cpfx}favbims",
+                "Returns each rider's most-ridden vehicle.",
             )
                 .add_lookback_flags()
                 .build()
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "bimridertypes".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}bimridertypes [-n] USERNAME".to_owned(),
-                "Returns the types of vehicles ridden by a rider.".to_owned(),
+                "topbimdays",
+                "bim",
+                "{cpfx}topbimdays",
+                "Returns the days with the most vehicle rides.",
+            )
+                .add_lookback_flags()
+                .build()
+        ).await;
+        my_interface.register_channel_command(
+            &CommandDefinitionBuilder::new(
+                "bimridertypes",
+                "bim",
+                "{cpfx}bimridertypes [-n] USERNAME",
+                "Returns the types of vehicles ridden by a rider.",
             )
                 .add_flag("n")
                 .add_flag("sort-by-number")
@@ -2544,10 +2544,10 @@ impl RocketBotPlugin for BimPlugin {
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "bimriderlines".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}bimriderlines [-n] USERNAME".to_owned(),
-                "Returns the lines ridden by a rider.".to_owned(),
+                "bimriderlines",
+                "bim",
+                "{cpfx}bimriderlines [-n] USERNAME",
+                "Returns the lines ridden by a rider.",
             )
                 .add_flag("n")
                 .add_flag("sort-by-number")
@@ -2556,10 +2556,10 @@ impl RocketBotPlugin for BimPlugin {
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "bimranges".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}bimranges [-p] [-c COMPANY]".to_owned(),
-                "Returns the number ranges of each vehicle type.".to_owned(),
+                "bimranges",
+                "bim",
+                "{cpfx}bimranges [-p] [-c COMPANY]",
+                "Returns the number ranges of each vehicle type.",
             )
                 .add_flag("precise")
                 .add_flag("p")
@@ -2569,10 +2569,10 @@ impl RocketBotPlugin for BimPlugin {
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "bimtypes".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}bimtypes [-c COMPANY] [USERNAME]".to_owned(),
-                "Returns statistics about vehicle types.".to_owned(),
+                "bimtypes",
+                "bim",
+                "{cpfx}bimtypes [-c COMPANY] [USERNAME]",
+                "Returns statistics about vehicle types.",
             )
                 .add_option("company", CommandValueType::String)
                 .add_option("c", CommandValueType::String)
@@ -2580,10 +2580,10 @@ impl RocketBotPlugin for BimPlugin {
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "fixbimride".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}fixbimride OPTIONS".to_owned(),
-                "Fix some data in a bim ride.".to_owned(),
+                "fixbimride",
+                "bim",
+                "{cpfx}fixbimride OPTIONS",
+                "Fix some data in a bim ride.",
             )
                 .add_flag("d")
                 .add_flag("delete")
@@ -2601,10 +2601,10 @@ impl RocketBotPlugin for BimPlugin {
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "widestbims".to_owned(),
-                "bim".to_owned(),
-                "{cpfx}widestbims".to_owned(),
-                "Lists vehicles that have served the widest selection of riders.".to_owned(),
+                "widestbims",
+                "bim",
+                "{cpfx}widestbims",
+                "Lists vehicles that have served the widest selection of riders.",
             )
                 .add_lookback_flags()
                 .build()

--- a/rocketbot_plugin_calc/src/lib.rs
+++ b/rocketbot_plugin_calc/src/lib.rs
@@ -8,7 +8,6 @@ mod parsing;
 mod units;
 
 
-use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 use std::sync::{Arc, Weak};
@@ -19,9 +18,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use log::error;
 use num_bigint::BigUint;
 use rocketbot_interface::{JsonValueExtensions, ResultExtensions, send_channel_message};
-use rocketbot_interface::commands::{
-    CommandBehaviors, CommandDefinition, CommandDefinitionBuilder, CommandInstance,
-};
+use rocketbot_interface::commands::{CommandBehaviors, CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::{Mutex, run_stoppable_task_timeout, RwLock, StoppableTaskResult};
@@ -317,40 +314,40 @@ impl RocketBotPlugin for CalcPlugin {
             PrimeCache::new(),
         ));
 
-        my_interface.register_channel_command(&CommandDefinition::new(
-            "calc".to_owned(),
-            "calc".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::NO_ARGUMENT_PARSING,
-            "{cpfx}calc EXPRESSION".to_owned(),
-            "Calculates the given mathematical expression and outputs the result.".to_owned(),
-        )).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "calcconst".to_owned(),
-                "calc".to_owned(),
-                "{cpfx}calcconst".to_owned(),
-                "Lists available calculator constants.".to_owned(),
+                "calc",
+                "calc",
+                "{cpfx}calc EXPRESSION",
+                "Calculates the given mathematical expression and outputs the result.",
+            )
+                .behaviors(CommandBehaviors::NO_ARGUMENT_PARSING)
+                .build()
+        ).await;
+        my_interface.register_channel_command(
+            &CommandDefinitionBuilder::new(
+                "calcconst",
+                "calc",
+                "{cpfx}calcconst",
+                "Lists available calculator constants.",
             )
                 .build()
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "calcfunc".to_owned(),
-                "calc".to_owned(),
-                "{cpfx}calcfunc".to_owned(),
-                "Lists available calculator functions.".to_owned(),
+                "calcfunc",
+                "calc",
+                "{cpfx}calcfunc",
+                "Lists available calculator functions.",
             )
                 .build()
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "factor".to_owned(),
-                "calc".to_owned(),
-                "{cpfx}factor NUMBER".to_owned(),
-                "Attempts to subdivide the given natural number into its prime factors.".to_owned(),
+                "factor",
+                "calc",
+                "{cpfx}factor NUMBER",
+                "Attempts to subdivide the given natural number into its prime factors.",
             )
                 .add_flag("c").add_flag("code")
                 .build()

--- a/rocketbot_plugin_catchword/src/lib.rs
+++ b/rocketbot_plugin_catchword/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Weak;
 
 use async_trait::async_trait;
@@ -7,7 +7,7 @@ use rand::{Rng, SeedableRng};
 use rand::rngs::StdRng;
 use regex::{Match, Regex};
 use rocketbot_interface::{JsonValueExtensions, ResultExtensions, send_channel_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::{Mutex, RwLock};
@@ -87,16 +87,15 @@ impl CatchwordPlugin {
     }
 
     async fn register_catchword_command<I: RocketBotInterface + ?Sized>(interface: &I, catch_name: &str) {
-        interface.register_channel_command(&CommandDefinition::new(
-            catch_name.to_owned(),
-            "catchword".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            format!("{{cpfx}}{} PHRASE", catch_name),
-            "Performs replacements in the PHRASE according to preconfigured rules.".to_owned(),
-        )).await;
+        interface.register_channel_command(
+            &CommandDefinitionBuilder::new(
+                catch_name,
+                "catchword",
+                format!("{{cpfx}}{} PHRASE", catch_name),
+                "Performs replacements in the PHRASE according to preconfigured rules.",
+            )
+                .build()
+        ).await;
     }
 }
 #[async_trait]

--- a/rocketbot_plugin_date/src/lib.rs
+++ b/rocketbot_plugin_date/src/lib.rs
@@ -131,20 +131,20 @@ impl RocketBotPlugin for DatePlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "weekday".to_string(),
-                "date".to_owned(),
-                "{cpfx}weekday DATE".to_owned(),
-                "Reports the weekday of the specified date.".to_owned(),
+                "weekday",
+                "date",
+                "{cpfx}weekday DATE",
+                "Reports the weekday of the specified date.",
             )
                 .build()
         ).await;
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "days".to_string(),
-                "date".to_owned(),
-                "{cpfx}days DATE".to_owned(),
-                "Reports the difference, in days, between today and the specified date.".to_owned(),
+                "days",
+                "date",
+                "{cpfx}days DATE",
+                "Reports the difference, in days, between today and the specified date.",
             )
                 .build()
         ).await;

--- a/rocketbot_plugin_dice/src/lib.rs
+++ b/rocketbot_plugin_dice/src/lib.rs
@@ -13,10 +13,7 @@ use rand::seq::SliceRandom;
 use rand::rngs::StdRng;
 use regex::{Captures, Regex};
 use rocketbot_interface::{ResultExtensions, send_channel_message};
-use rocketbot_interface::commands::{
-    CommandBehaviors, CommandDefinition, CommandDefinitionBuilder, CommandInstance,
-    CommandValueType,
-};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance,CommandValueType};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::{Mutex, RwLock};
@@ -683,75 +680,59 @@ impl RocketBotPlugin for DicePlugin {
             HashMap::new(),
         );
 
-        let roll_command = CommandDefinition::new(
-            "roll".to_string(),
-            "dice".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}roll DICE [DICE ...]".to_owned(),
-            "Rolls one or more dice.".to_owned(),
-        );
+        let roll_command = CommandDefinitionBuilder::new(
+            "roll",
+            "dice",
+            "{cpfx}roll DICE [DICE ...]",
+            "Rolls one or more dice.",
+        )
+            .build();
         my_interface.register_channel_command(&roll_command).await;
 
-        let yn_command = CommandDefinition::new(
-            "yn".to_string(),
-            "dice".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}yn [QUESTION]".to_owned(),
-            "Helps you make a decision (or not) by answering a yes/no question.".to_owned(),
-        );
+        let yn_command = CommandDefinitionBuilder::new(
+            "yn",
+            "dice",
+            "{cpfx}yn [QUESTION]",
+            "Helps you make a decision (or not) by answering a yes/no question.",
+        )
+            .build();
         my_interface.register_channel_command(&yn_command).await;
 
-        let decide_command = CommandDefinition::new(
-            "decide".to_string(),
-            "dice".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}decide OPTION or OPTION [or OPTION...]".to_owned(),
-            "Helps you make a decision (or not) by choosing one of multiple options.".to_owned(),
-        );
+        let decide_command = CommandDefinitionBuilder::new(
+            "decide",
+            "dice",
+            "{cpfx}decide OPTION or OPTION [or OPTION...]",
+            "Helps you make a decision (or not) by choosing one of multiple options.",
+        )
+            .build();
         my_interface.register_channel_command(&decide_command).await;
 
-        let shuffle_command = CommandDefinition::new(
-            "shuffle".to_string(),
-            "dice".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}shuffle OPTION or OPTION [or OPTION...]".to_owned(),
-            "Helps you prioritize by shuffling the options.".to_owned(),
-        );
+        let shuffle_command = CommandDefinitionBuilder::new(
+            "shuffle",
+            "dice",
+            "{cpfx}shuffle OPTION or OPTION [or OPTION...]",
+            "Helps you prioritize by shuffling the options.",
+        )
+            .build();
         my_interface.register_channel_command(&shuffle_command).await;
 
-        let mut wikipedia_options = HashMap::new();
-        wikipedia_options.insert("w".to_string(), CommandValueType::String);
-        wikipedia_options.insert("wikipedia".to_string(), CommandValueType::String);
-        let some_year_command = CommandDefinition::new(
-            "someyear".to_string(),
-            "dice".to_owned(),
-            Some(HashSet::new()),
-            wikipedia_options,
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}someyear [{lopfx}wikipedia WP]".to_owned(),
-            "Selects a random year and links to its Wikipedia article.".to_owned(),
-        );
+        let some_year_command = CommandDefinitionBuilder::new(
+            "someyear",
+            "dice",
+            "{cpfx}someyear [{lopfx}wikipedia WP]",
+            "Selects a random year and links to its Wikipedia article.",
+        )
+            .add_option("w", CommandValueType::String)
+            .add_option("wikipedia", CommandValueType::String)
+            .build();
         my_interface.register_channel_command(&some_year_command).await;
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "randwordle".to_owned(),
-                "dice".to_owned(),
-                "{cpfx}randwordle [OPTIONS]".to_owned(),
-                "Generates a random Wordle solution pattern.".to_owned(),
+                "randwordle",
+                "dice",
+                "{cpfx}randwordle [OPTIONS]",
+                "Generates a random Wordle solution pattern.",
             )
                 .add_option("s", CommandValueType::Integer)
                 .add_option("squares", CommandValueType::Integer)

--- a/rocketbot_plugin_fact/src/lib.rs
+++ b/rocketbot_plugin_fact/src/lib.rs
@@ -2,7 +2,6 @@ pub mod interface;
 pub mod providers;
 
 
-use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
@@ -10,7 +9,7 @@ use log::error;
 use rand::{Rng, RngCore, SeedableRng};
 use rand::rngs::StdRng;
 use rocketbot_interface::{JsonValueExtensions, send_channel_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::{Mutex, RwLock};
@@ -102,16 +101,13 @@ impl RocketBotPlugin for FactPlugin {
             Box::new(StdRng::from_entropy()) as Box<dyn RngCore + Send>,
         ));
 
-        let fact_command = CommandDefinition::new(
-            "fact".to_owned(),
-            "fact".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}fact".to_owned(),
-            "Obtains and displays a random fact.".to_owned(),
-        );
+        let fact_command = CommandDefinitionBuilder::new(
+            "fact",
+            "fact",
+            "{cpfx}fact",
+            "Obtains and displays a random fact.",
+        )
+            .build();
         my_interface.register_channel_command(&fact_command).await;
 
         FactPlugin {

--- a/rocketbot_plugin_fortune/src/lib.rs
+++ b/rocketbot_plugin_fortune/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -9,7 +9,7 @@ use log::error;
 use rand::{Rng, SeedableRng};
 use rand::rngs::StdRng;
 use rocketbot_interface::{JsonValueExtensions, ResultExtensions, send_channel_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::{Mutex, RwLock};
@@ -76,16 +76,13 @@ impl RocketBotPlugin for FortunePlugin {
             config_object,
         );
 
-        let fortune_command = CommandDefinition::new(
-            "fortune".to_owned(),
-            "fortune".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}fortune [GROUP]".to_owned(),
-            "Selects and displays a random fortune, optionally from a specific group.".to_owned(),
-        );
+        let fortune_command = CommandDefinitionBuilder::new(
+            "fortune",
+            "fortune",
+            "{cpfx}fortune [GROUP]",
+            "Selects and displays a random fortune, optionally from a specific group.",
+        )
+            .build();
         my_interface.register_channel_command(&fortune_command).await;
 
         let rng = Mutex::new(

--- a/rocketbot_plugin_grammargen/src/lib.rs
+++ b/rocketbot_plugin_grammargen/src/lib.rs
@@ -13,7 +13,7 @@ use log::error;
 use rand::{Rng, SeedableRng};
 use rand::rngs::StdRng;
 use rocketbot_interface::{JsonValueExtensions, ResultExtensions, send_channel_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::RwLock;
@@ -101,16 +101,16 @@ impl GrammarGenPlugin {
     }
 
     async fn register_grammar_command<I: RocketBotInterface + ?Sized>(interface: &I, grammar_name: &str) {
-        interface.register_channel_command(&CommandDefinition::new(
-            grammar_name.to_owned(),
-            "grammargen".to_owned(),
-            None,
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            format!("{{cpfx}}{} [NICKNAME]", grammar_name),
-            "Produces a phrase from the given grammar.".to_owned(),
-        )).await;
+        interface.register_channel_command(
+            &CommandDefinitionBuilder::new(
+                grammar_name,
+                "grammargen",
+                format!("{{cpfx}}{} [NICKNAME]", grammar_name),
+                "Produces a phrase from the given grammar.",
+            )
+                .any_flags()
+                .build()
+        ).await;
     }
 }
 #[async_trait]

--- a/rocketbot_plugin_help/src/lib.rs
+++ b/rocketbot_plugin_help/src/lib.rs
@@ -1,11 +1,10 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
 use rocketbot_interface::{send_channel_message, send_private_message};
 use rocketbot_interface::commands::{
-    CommandBehaviors, CommandConfiguration, CommandDefinition, CommandDefinitionBuilder,
-    CommandInstance,
+    CommandConfiguration, CommandDefinition, CommandDefinitionBuilder, CommandInstance,
 };
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::{ChannelMessage, PrivateMessage};
@@ -240,50 +239,41 @@ impl RocketBotPlugin for HelpPlugin {
             Some(i) => i,
         };
 
-        let help_command = CommandDefinition::new(
-            "help".to_owned(),
-            "help".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}help [COMMAND]".to_owned(),
-            "Shows help about the given command, or lists all available commands.".to_owned(),
-        );
+        let help_command = CommandDefinitionBuilder::new(
+            "help",
+            "help",
+            "{cpfx}help [COMMAND]",
+            "Shows help about the given command, or lists all available commands.",
+        )
+            .build();
         my_interface.register_channel_command(&help_command).await;
         my_interface.register_private_message_command(&help_command).await;
 
-        let helpplug_command = CommandDefinition::new(
-            "helpplug".to_owned(),
-            "help".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}helpplug PLUGIN".to_owned(),
-            "Lists all available commands, including usage information, provided by the given plugin.".to_owned(),
-        );
+        let helpplug_command = CommandDefinitionBuilder::new(
+            "helpplug",
+            "help",
+            "{cpfx}helpplug PLUGIN",
+            "Lists all available commands, including usage information, provided by the given plugin.",
+        )
+            .build();
         my_interface.register_channel_command(&helpplug_command).await;
         my_interface.register_private_message_command(&helpplug_command).await;
 
-        let usage_command = CommandDefinition::new(
-            "usage".to_owned(),
-            "help".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}usage COMMAND".to_owned(),
-            "Shows usage information for the given command.".to_owned(),
-        );
+        let usage_command = CommandDefinitionBuilder::new(
+            "usage",
+            "help",
+            "{cpfx}usage COMMAND",
+            "Shows usage information for the given command.",
+        )
+            .build();
         my_interface.register_channel_command(&usage_command).await;
         my_interface.register_private_message_command(&usage_command).await;
 
         let whichplugin_command = CommandDefinitionBuilder::new(
-            "whichplugin".to_owned(),
-            "help".to_owned(),
-            "{cpfx}whichplugin COMMAND".to_owned(),
-            "Displays which plugin provides the given command.".to_owned(),
+            "whichplugin",
+            "help",
+            "{cpfx}whichplugin COMMAND",
+            "Displays which plugin provides the given command.",
         )
             .build();
         my_interface.register_channel_command(&whichplugin_command).await;

--- a/rocketbot_plugin_nines/src/lib.rs
+++ b/rocketbot_plugin_nines/src/lib.rs
@@ -1,4 +1,3 @@
-use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Weak;
@@ -9,7 +8,7 @@ use log::error;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rocketbot_interface::send_channel_message;
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 
@@ -77,16 +76,15 @@ impl RocketBotPlugin for NinesPlugin {
             Some(i) => i,
         };
 
-        my_interface.register_channel_command(&CommandDefinition::new(
-            "nines".to_owned(),
-            "nines".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}nines NUMBER|NUMBER NUMBERs|NUMBER%".to_owned(),
-            "Calculates allowed downtime for an uptime expressed as a number of nines.".to_owned(),
-        )).await;
+        my_interface.register_channel_command(
+            &CommandDefinitionBuilder::new(
+                "nines",
+                "nines",
+                "{cpfx}nines NUMBER|NUMBER NUMBERs|NUMBER%",
+                "Calculates allowed downtime for an uptime expressed as a number of nines.",
+            )
+                .build()
+        ).await;
 
         NinesPlugin {
             interface,

--- a/rocketbot_plugin_numberword/src/lib.rs
+++ b/rocketbot_plugin_numberword/src/lib.rs
@@ -152,10 +152,10 @@ impl RocketBotPlugin for NumberwordPlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "unkeypad".to_owned(),
-                "numberword".to_owned(),
-                "{cpfx}unkeypad NUMBER".to_owned(),
-                "Attempts to guess the word described by the phone-keypad number.".to_owned(),
+                "unkeypad",
+                "numberword",
+                "{cpfx}unkeypad NUMBER",
+                "Attempts to guess the word described by the phone-keypad number.",
             )
                 .build()
         ).await;

--- a/rocketbot_plugin_paper/src/lib.rs
+++ b/rocketbot_plugin_paper/src/lib.rs
@@ -1,4 +1,3 @@
-use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Write;
 use std::ops::Deref;
@@ -12,7 +11,7 @@ use num_traits::{FromPrimitive, One, Zero};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rocketbot_interface::{ResultExtensions, send_channel_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::RwLock;
@@ -291,16 +290,15 @@ impl RocketBotPlugin for PaperPlugin {
             config_object,
         );
 
-        my_interface.register_channel_command(&CommandDefinition::new(
-            "paper".to_owned(),
-            "paper".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}paper PAPER".to_owned(),
-            "Displays the size of the given ISO 216-like paper.".to_owned(),
-        )).await;
+        my_interface.register_channel_command(
+            &CommandDefinitionBuilder::new(
+                "paper",
+                "paper",
+                "{cpfx}paper PAPER",
+                "Displays the size of the given ISO 216-like paper.",
+            )
+                .build()
+        ).await;
 
         PaperPlugin {
             interface,

--- a/rocketbot_plugin_progress/src/lib.rs
+++ b/rocketbot_plugin_progress/src/lib.rs
@@ -65,10 +65,10 @@ impl RocketBotPlugin for ProgressPlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "progress".to_owned(),
-                "progress".to_owned(),
-                "{cpfx}progress TEXT".to_owned(),
-                "Annotates percentages in the text with progress bars.".to_owned(),
+                "progress",
+                "progress",
+                "{cpfx}progress TEXT",
+                "Annotates percentages in the text with progress bars.",
             )
                 .add_option("f", CommandValueType::String)
                 .add_option("foreground", CommandValueType::String)

--- a/rocketbot_plugin_quotes/src/lib.rs
+++ b/rocketbot_plugin_quotes/src/lib.rs
@@ -12,7 +12,7 @@ use rand::{Rng, SeedableRng};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rocketbot_interface::{JsonValueExtensions, send_channel_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::{Mutex, RwLock};
@@ -792,28 +792,23 @@ impl RocketBotPlugin for QuotesPlugin {
             ),
         );
 
-        let addquote_command = CommandDefinition::new(
+        let addquote_command = CommandDefinitionBuilder::new(
             format!("{}addquote", config_object.command_prefix),
-            "quotes".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
+            "quotes",
             format!("{{cpfx}}{}addquote QUOTE", config_object.command_prefix),
-            "Adds the given quote to the quote database.".to_owned(),
-        );
+            "Adds the given quote to the quote database.",
+        )
+            .build();
         my_interface.register_channel_command(&addquote_command).await;
 
-        let remember_command = CommandDefinition::new(
+        let remember_command = CommandDefinitionBuilder::new(
             format!("{}remember", config_object.command_prefix),
-            "quotes".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            1,
-            CommandBehaviors::empty(),
+            "quotes",
             format!("{{cpfx}}{}remember USERNAME SUBSTRING", config_object.command_prefix),
-            "Adds a recent utterance of the given user to the quote database.".to_owned(),
-        );
+            "Adds a recent utterance of the given user to the quote database.",
+        )
+            .arg_count(1)
+            .build();
         my_interface.register_channel_command(&remember_command).await;
 
         let mut quote_flags = HashSet::new();
@@ -824,52 +819,45 @@ impl RocketBotPlugin for QuotesPlugin {
         let mut quote_case_flags = quote_flags.clone();
         quote_case_flags.insert("c".to_owned());
 
-        let quote_command = CommandDefinition::new(
+        let quote_command = CommandDefinitionBuilder::new(
             format!("{}quote", config_object.command_prefix),
-            "quotes".to_owned(),
-            Some(quote_case_flags.clone()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
+            "quotes",
             format!("{{cpfx}}{}quote [{{lopfx}}any|{{lopfx}}bad] [{{sopfx}}r] [{{sopfx}}c] [SUBSTRING]", config_object.command_prefix),
-            "Outputs a random quote containing the given substring.".to_owned(),
-        );
+            "Outputs a random quote containing the given substring.",
+        )
+            .flags(Some(quote_case_flags.clone()))
+            .build();
         my_interface.register_channel_command(&quote_command).await;
 
-        let quoteuser_command = CommandDefinition::new(
+        let quoteuser_command = CommandDefinitionBuilder::new(
             format!("{}quoteuser", config_object.command_prefix),
-            "quotes".to_owned(),
-            Some(quote_case_flags.clone()),
-            HashMap::new(),
-            1,
-            CommandBehaviors::empty(),
+            "quotes",
             format!("{{cpfx}}{}quoteuser [{{lopfx}}any|{{lopfx}}bad] [{{sopfx}}r] [{{sopfx}}c] USERNAME [SUBSTRING]", config_object.command_prefix),
-            "Outputs a random quote from the given user containing the given substring.".to_owned(),
-        );
+            "Outputs a random quote from the given user containing the given substring.",
+        )
+            .flags(Some(quote_case_flags.clone()))
+            .arg_count(1)
+            .build();
         my_interface.register_channel_command(&quoteuser_command).await;
 
-        let nextquote_command = CommandDefinition::new(
+        let nextquote_command = CommandDefinitionBuilder::new(
             format!("{}nextquote", config_object.command_prefix),
-            "quotes".to_owned(),
-            Some(quote_flags.clone()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
+            "quotes",
             format!("{{cpfx}}{}nextquote [{{lopfx}}any|{{lopfx}}bad] [{{sopfx}}r]", config_object.command_prefix),
-            "Displays the next quote from a pre-shuffled list of quotes.".to_owned(),
-        );
+            "Displays the next quote from a pre-shuffled list of quotes.",
+        )
+            .flags(Some(quote_flags.clone()))
+            .build();
         my_interface.register_channel_command(&nextquote_command).await;
 
-        let upquote_command = CommandDefinition::new(
+        let upquote_command = CommandDefinitionBuilder::new(
             format!("{}upquote", config_object.command_prefix),
-            "quotes".to_owned(),
-            Some(quote_flags.clone()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
+            "quotes",
             format!("{{cpfx}}{0}uq|{{cpfx}}{0}upquote|{{cpfx}}{0}dq|{{cpfx}}{0}downquote", config_object.command_prefix),
-            "Updates the most recently added or displayed quote with a positive or a negative vote from you.".to_owned(),
-        );
+            "Updates the most recently added or displayed quote with a positive or a negative vote from you.",
+        )
+            .flags(Some(quote_flags.clone()))
+            .build();
         let uq_command = upquote_command.copy_named(&format!("{}uq", config_object.command_prefix));
         let downquote_command = upquote_command.copy_named(&format!("{}downquote", config_object.command_prefix));
         let dq_command = upquote_command.copy_named(&format!("{}dq", config_object.command_prefix));

--- a/rocketbot_plugin_roman_num/src/lib.rs
+++ b/rocketbot_plugin_roman_num/src/lib.rs
@@ -71,19 +71,19 @@ impl RocketBotPlugin for RomanNumPlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "roman".to_owned(),
-                "roman_num".to_owned(),
-                "{cpfx}roman NUMBER".to_owned(),
-                "Converts the given number, given in Arabic digits, into Roman numerals.".to_owned(),
+                "roman",
+                "roman_num",
+                "{cpfx}roman NUMBER",
+                "Converts the given number, given in Arabic digits, into Roman numerals.",
             )
                 .build()
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "unroman".to_owned(),
-                "roman_num".to_owned(),
-                "{cpfx}unroman ROMAN".to_owned(),
-                "Converts the given number, given in Roman numerals, into Arabic digits.".to_owned(),
+                "unroman",
+                "roman_num",
+                "{cpfx}unroman ROMAN",
+                "Converts the given number, given in Roman numerals, into Arabic digits.",
             )
                 .build()
         ).await;

--- a/rocketbot_plugin_sed/src/lib.rs
+++ b/rocketbot_plugin_sed/src/lib.rs
@@ -234,30 +234,30 @@ impl RocketBotPlugin for SedPlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "sedparse".to_owned(),
-                "sed".to_owned(),
-                "{cpfx}sedparse SEDCOMMANDS".to_owned(),
-                "Attempts to parse one or more sed commands and pinpoint issues.".to_owned(),
+                "sedparse",
+                "sed",
+                "{cpfx}sedparse SEDCOMMANDS",
+                "Attempts to parse one or more sed commands and pinpoint issues.",
             )
                 .behaviors(CommandBehaviors::NO_ARGUMENT_PARSING)
                 .build()
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "sedany".to_owned(),
-                "sed".to_owned(),
-                "{cpfx}sedany SEDCOMMANDS".to_owned(),
-                "Performs the given sed command(s) on the most recent message where at least one command matches.".to_owned(),
+                "sedany",
+                "sed",
+                "{cpfx}sedany SEDCOMMANDS",
+                "Performs the given sed command(s) on the most recent message where at least one command matches.",
             )
                 .behaviors(CommandBehaviors::NO_ARGUMENT_PARSING)
                 .build()
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "sedall".to_owned(),
-                "sed".to_owned(),
-                "{cpfx}sedall SEDCOMMANDS".to_owned(),
-                "Performs the given sed command(s) on the most recent message where all commands match.".to_owned(),
+                "sedall",
+                "sed",
+                "{cpfx}sedall SEDCOMMANDS",
+                "Performs the given sed command(s) on the most recent message where all commands match.",
             )
                 .behaviors(CommandBehaviors::NO_ARGUMENT_PARSING)
                 .build()

--- a/rocketbot_plugin_serious_mode/src/lib.rs
+++ b/rocketbot_plugin_serious_mode/src/lib.rs
@@ -22,20 +22,20 @@ impl RocketBotPlugin for SeriousModePlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "srs".to_owned(),
-                "serious_mode".to_owned(),
-                "{cpfx}srs".to_owned(),
-                "Activates Serious Mode for some amount of time.".to_owned(),
+                "srs",
+                "serious_mode",
+                "{cpfx}srs",
+                "Activates Serious Mode for some amount of time.",
             )
                 .build()
         ).await;
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "unsrs".to_owned(),
-                "serious_mode".to_owned(),
-                "{cpfx}unsrs".to_owned(),
-                "Deactivates Serious Mode.".to_owned(),
+                "unsrs",
+                "serious_mode",
+                "{cpfx}unsrs",
+                "Deactivates Serious Mode.",
             )
                 .build()
         ).await;

--- a/rocketbot_plugin_slogan/src/lib.rs
+++ b/rocketbot_plugin_slogan/src/lib.rs
@@ -176,10 +176,10 @@ impl RocketBotPlugin for SloganPlugin {
         );
 
         let slogan_command = CommandDefinitionBuilder::new(
-            "slogan".to_owned(),
-            "slogan".to_owned(),
-            "{cpfx}slogan [SUBJECT]".to_owned(),
-            "Generates and outputs a generic marketing slogan about SUBJECT.".to_owned(),
+            "slogan",
+            "slogan",
+            "{cpfx}slogan [SUBJECT]",
+            "Generates and outputs a generic marketing slogan about SUBJECT.",
         )
             .build();
         my_interface.register_channel_command(&slogan_command).await;

--- a/rocketbot_plugin_sockpuppet/src/lib.rs
+++ b/rocketbot_plugin_sockpuppet/src/lib.rs
@@ -1,12 +1,10 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Weak;
 
 use async_trait::async_trait;
 use log::error;
 use rocketbot_interface::{JsonValueExtensions, send_channel_message_advanced};
-use rocketbot_interface::commands::{
-    CommandBehaviors, CommandDefinition, CommandInstance, CommandValueType,
-};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance, CommandValueType};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::{ImpersonationInfo, OutgoingMessage, PrivateMessage};
 use rocketbot_interface::sync::RwLock;
@@ -116,18 +114,15 @@ impl RocketBotPlugin for SockpuppetPlugin {
             config_object,
         );
 
-        let mut chansend_options = HashMap::new();
-        chansend_options.insert("impersonate".to_owned(), CommandValueType::String);
-        let chansend_command = CommandDefinition::new(
-            "chansend".to_owned(),
-            "sockpuppet".to_owned(),
-            Some(HashSet::new()),
-            chansend_options,
-            1,
-            CommandBehaviors::empty(),
-            "{cpfx}chansend [{lopfx}impersonate USERNAME] CHANNEL MESSAGE".to_owned(),
-            "Sends a message, pretending to be the bot or someone else.".to_owned(),
-        );
+        let chansend_command = CommandDefinitionBuilder::new(
+            "chansend",
+            "sockpuppet",
+            "{cpfx}chansend [{lopfx}impersonate USERNAME] CHANNEL MESSAGE",
+            "Sends a message, pretending to be the bot or someone else.",
+        )
+            .add_option("impersonate", CommandValueType::String)
+            .arg_count(1)
+            .build();
         my_interface.register_private_message_command(&chansend_command).await;
 
         SockpuppetPlugin {

--- a/rocketbot_plugin_syllable/src/lib.rs
+++ b/rocketbot_plugin_syllable/src/lib.rs
@@ -145,10 +145,10 @@ impl RocketBotPlugin for SyllablePlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "syl".to_owned(),
-                "syllable".to_owned(),
-                "{cpfx}syl TEXT".to_owned(),
-                "Calculates the number of syllables in a text.".to_owned(),
+                "syl",
+                "syllable",
+                "{cpfx}syl TEXT",
+                "Calculates the number of syllables in a text.",
             )
                 .build()
         ).await;

--- a/rocketbot_plugin_text/src/lib.rs
+++ b/rocketbot_plugin_text/src/lib.rs
@@ -86,10 +86,10 @@ impl RocketBotPlugin for TextPlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "compare".to_owned(),
-                "text".to_owned(),
-                "{cpfx}compare STRING1 STRING2".to_owned(),
-                "Outputs information about how much two strings differ.".to_owned(),
+                "compare",
+                "text",
+                "{cpfx}compare STRING1 STRING2",
+                "Outputs information about how much two strings differ.",
             )
                 .arg_count(2)
                 .build()

--- a/rocketbot_plugin_thanks/src/lib.rs
+++ b/rocketbot_plugin_thanks/src/lib.rs
@@ -1,4 +1,3 @@
-use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use std::sync::Weak;
 
@@ -6,7 +5,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use log::{error, info};
 use rocketbot_interface::{JsonValueExtensions, send_channel_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::RwLock;
@@ -455,65 +454,53 @@ impl RocketBotPlugin for ThanksPlugin {
             config_object,
         );
 
-        let thanks_command = CommandDefinition::new(
-            "thanks".to_owned(),
-            "thanks".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            1,
-            CommandBehaviors::empty(),
-            "{cpfx}thanks|{cpfx}thank|{cpfx}thx USERNAME [REASON]".to_owned(),
-            "Thanks a user.".to_owned(),
-        );
+        let thanks_command = CommandDefinitionBuilder::new(
+            "thanks",
+            "thanks",
+            "{cpfx}thanks|{cpfx}thank|{cpfx}thx USERNAME [REASON]",
+            "Thanks a user.",
+        )
+            .arg_count(1)
+            .build();
         let thank_command = thanks_command.copy_named("thank");
         let thx_command = thanks_command.copy_named("thx");
         my_interface.register_channel_command(&thanks_command).await;
         my_interface.register_channel_command(&thank_command).await;
         my_interface.register_channel_command(&thx_command).await;
 
-        let thanked_command = CommandDefinition::new(
-            "thanked".to_owned(),
-            "thanks".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            1,
-            CommandBehaviors::empty(),
-            "{cpfx}thanked USERNAME".to_owned(),
-            "Displays how often the given user has been thanked.".to_owned(),
-        );
-        let grateful_command = CommandDefinition::new(
-            "grateful".to_owned(),
-            "thanks".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            1,
-            CommandBehaviors::empty(),
-            "{cpfx}grateful USERNAME".to_owned(),
-            "Displays how often the given user has thanked others.".to_owned(),
-        );
+        let thanked_command = CommandDefinitionBuilder::new(
+            "thanked",
+            "thanks",
+            "{cpfx}thanked USERNAME",
+            "Displays how often the given user has been thanked.",
+        )
+            .arg_count(1)
+            .build();
+        let grateful_command = CommandDefinitionBuilder::new(
+            "grateful",
+            "thanks",
+            "{cpfx}grateful USERNAME",
+            "Displays how often the given user has thanked others.",
+        )
+            .arg_count(1)
+            .build();
         my_interface.register_channel_command(&thanked_command).await;
         my_interface.register_channel_command(&grateful_command).await;
 
-        let topthanked_command = CommandDefinition::new(
-            "topthanked".to_owned(),
-            "thanks".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}topthanked".to_owned(),
-            "Displays the top thanked users to the knowledge of this bot.".to_owned(),
-        );
-        let topgrateful_command = CommandDefinition::new(
-            "topgrateful".to_owned(),
-            "thanks".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}topgrateful".to_owned(),
-            "Displays the top grateful users to the knowledge of this bot.".to_owned(),
-        );
+        let topthanked_command = CommandDefinitionBuilder::new(
+            "topthanked",
+            "thanks",
+            "{cpfx}topthanked",
+            "Displays the top thanked users to the knowledge of this bot.",
+        )
+            .build();
+        let topgrateful_command = CommandDefinitionBuilder::new(
+            "topgrateful",
+            "thanks",
+            "{cpfx}topgrateful",
+            "Displays the top grateful users to the knowledge of this bot.",
+        )
+            .build();
         my_interface.register_channel_command(&topthanked_command).await;
         my_interface.register_channel_command(&topgrateful_command).await;
 

--- a/rocketbot_plugin_time/src/lib.rs
+++ b/rocketbot_plugin_time/src/lib.rs
@@ -153,10 +153,10 @@ impl RocketBotPlugin for TimePlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "time".to_owned(),
-                "time".to_owned(),
-                "{cpfx}time [-r] LOCATION".to_owned(),
-                "Shows the current time at the given location.".to_owned(),
+                "time",
+                "time",
+                "{cpfx}time [-r] LOCATION",
+                "Shows the current time at the given location.",
             )
                 .add_flag("not")
                 .add_flag("n")

--- a/rocketbot_plugin_transliterate/src/lib.rs
+++ b/rocketbot_plugin_transliterate/src/lib.rs
@@ -302,8 +302,8 @@ impl TransliteratePlugin {
             interface.register_channel_command(
                 &CommandDefinitionBuilder::new(
                     command.clone(),
-                    "transliterate".to_owned(),
-                    "{cpfx}{cmd} PHRASE".to_owned(),
+                    "transliterate",
+                    "{cpfx}{cmd} PHRASE",
                     format!(
                         "Transliterates text from {} to {}.",
                         source_lang.name, dest_lang.name,
@@ -327,29 +327,29 @@ impl RocketBotPlugin for TransliteratePlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "languages".to_owned(),
-                "transliterate".to_owned(),
-                "{cpfx}languages".to_owned(),
-                "Transliterates text from a specific language to the intermediate language.".to_owned(),
+                "languages",
+                "transliterate",
+                "{cpfx}languages",
+                "Transliterates text from a specific language to the intermediate language.",
             )
                 .build(),
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "detransliterate".to_owned(),
-                "transliterate".to_owned(),
-                "{cpfx}detransliterate LANG PHRASE".to_owned(),
-                "Transliterates text from a specific language to the intermediate language.".to_owned(),
+                "detransliterate",
+                "transliterate",
+                "{cpfx}detransliterate LANG PHRASE",
+                "Transliterates text from a specific language to the intermediate language.",
             )
                 .arg_count(1)
                 .build(),
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "entransliterate".to_owned(),
-                "transliterate".to_owned(),
-                "{cpfx}entransliterate LANG PHRASE".to_owned(),
-                "Transliterates text from the intermediate language to a specific language.".to_owned(),
+                "entransliterate",
+                "transliterate",
+                "{cpfx}entransliterate LANG PHRASE",
+                "Transliterates text from the intermediate language to a specific language.",
             )
                 .arg_count(1)
                 .build(),

--- a/rocketbot_plugin_vaccine/src/lib.rs
+++ b/rocketbot_plugin_vaccine/src/lib.rs
@@ -1,7 +1,7 @@
 mod database;
 
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Weak;
 
 use async_trait::async_trait;
@@ -10,7 +10,7 @@ use log::error;
 use num_bigint::{BigInt, BigUint};
 use num_traits::ToPrimitive;
 use rocketbot_interface::send_channel_message;
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::RwLock;
@@ -134,16 +134,13 @@ impl RocketBotPlugin for VaccinePlugin {
             config_object,
         );
 
-        let vaccine_command = CommandDefinition::new(
-            "vaccine".to_owned(),
-            "vaccine".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}vaccine [STATE]".to_owned(),
-            "Displays the number of vaccinated people in the given Austrian state or for all of Austria.".to_owned(),
-        );
+        let vaccine_command = CommandDefinitionBuilder::new(
+            "vaccine",
+            "vaccine",
+            "{cpfx}vaccine [STATE]",
+            "Displays the number of vaccinated people in the given Austrian state or for all of Austria.",
+        )
+            .build();
         my_interface.register_channel_command(&vaccine_command).await;
 
         VaccinePlugin {

--- a/rocketbot_plugin_version/src/lib.rs
+++ b/rocketbot_plugin_version/src/lib.rs
@@ -1,10 +1,9 @@
-use std::collections::{HashMap, HashSet};
 use std::sync::Weak;
 
 use async_trait::async_trait;
 use log::warn;
 use rocketbot_interface::{send_channel_message, send_private_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::{ChannelMessage, PrivateMessage};
 use serde_json;
@@ -26,16 +25,13 @@ impl RocketBotPlugin for VersionPlugin {
             Some(i) => i,
         };
 
-        let version_command = CommandDefinition::new(
-            "version".to_owned(),
-            "version".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}version".to_owned(),
-            "Outputs the currently running version of the bot.".to_owned(),
-        );
+        let version_command = CommandDefinitionBuilder::new(
+            "version",
+            "version",
+            "{cpfx}version",
+            "Outputs the currently running version of the bot.",
+        )
+            .build();
         my_interface.register_channel_command(&version_command).await;
         my_interface.register_private_message_command(&version_command).await;
 

--- a/rocketbot_plugin_vitals/src/lib.rs
+++ b/rocketbot_plugin_vitals/src/lib.rs
@@ -2,13 +2,13 @@ mod interface;
 mod readers;
 
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Weak;
 
 use async_trait::async_trait;
 use log::error;
 use rocketbot_interface::{JsonValueExtensions, send_channel_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::RwLock;
@@ -164,26 +164,24 @@ impl RocketBotPlugin for VitalsPlugin {
             config_object,
         );
 
-        my_interface.register_channel_command(&CommandDefinition::new(
-            "vitals".to_owned(),
-            "vitals".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}vitals [TARGET]".to_owned(),
-            "Obtains health-related information about the given target.".to_owned(),
-        )).await;
-        my_interface.register_channel_command(&CommandDefinition::new(
-            "vitallist".to_owned(),
-            "vitals".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}vitallist".to_owned(),
-            "Lists the available vitals targets.".to_owned(),
-        )).await;
+        my_interface.register_channel_command(
+            &CommandDefinitionBuilder::new(
+                "vitals",
+                "vitals",
+                "{cpfx}vitals [TARGET]",
+                "Obtains health-related information about the given target.",
+            )
+                .build()
+        ).await;
+        my_interface.register_channel_command(
+            &CommandDefinitionBuilder::new(
+                "vitallist",
+                "vitals",
+                "{cpfx}vitallist",
+                "Lists the available vitals targets.",
+            )
+                .build()
+        ).await;
 
         VitalsPlugin {
             interface,

--- a/rocketbot_plugin_weather/src/lib.rs
+++ b/rocketbot_plugin_weather/src/lib.rs
@@ -2,7 +2,7 @@ pub mod interface;
 pub mod providers;
 
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Weak;
 
 use async_trait::async_trait;
@@ -11,7 +11,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rocketbot_geocoding::{Geocoder, GeoCoordinates};
 use rocketbot_interface::{JsonValueExtensions, send_channel_message};
-use rocketbot_interface::commands::{CommandBehaviors, CommandDefinition, CommandInstance};
+use rocketbot_interface::commands::{CommandDefinitionBuilder, CommandInstance};
 use rocketbot_interface::interfaces::{RocketBotInterface, RocketBotPlugin};
 use rocketbot_interface::model::ChannelMessage;
 use rocketbot_interface::sync::RwLock;
@@ -208,16 +208,13 @@ impl RocketBotPlugin for WeatherPlugin {
             config_object,
         );
 
-        let weather_command = CommandDefinition::new(
-            "weather".to_owned(),
-            "weather".to_owned(),
-            Some(HashSet::new()),
-            HashMap::new(),
-            0,
-            CommandBehaviors::empty(),
-            "{cpfx}weather|{cpfx}lweather [LOCATION]".to_owned(),
-            "Displays the current weather as well as a forecast for the given location.".to_owned(),
-        );
+        let weather_command = CommandDefinitionBuilder::new(
+            "weather",
+            "weather",
+            "{cpfx}weather|{cpfx}lweather [LOCATION]",
+            "Displays the current weather as well as a forecast for the given location.",
+        )
+            .build();
         let lweather_command = weather_command.copy_named("lweather");
         let wetter_command = weather_command.copy_named("wetter");
         let owetter_command = weather_command.copy_named("owetter");

--- a/rocketbot_plugin_wienerlinien/src/lib.rs
+++ b/rocketbot_plugin_wienerlinien/src/lib.rs
@@ -508,10 +508,10 @@ impl RocketBotPlugin for WienerLinienPlugin {
 
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "dep".to_owned(),
-                "wienerlinien".to_owned(),
-                "{cpfx}dep [-l LINE] STATION".to_owned(),
-                "Shows public transport departures from a given station.".to_owned(),
+                "dep",
+                "wienerlinien",
+                "{cpfx}dep [-l LINE] STATION",
+                "Shows public transport departures from a given station.",
             )
                 .add_flag("s")
                 .add_flag("search")
@@ -521,10 +521,10 @@ impl RocketBotPlugin for WienerLinienPlugin {
         ).await;
         my_interface.register_channel_command(
             &CommandDefinitionBuilder::new(
-                "stations".to_owned(),
-                "wienerlinien".to_owned(),
-                "{cpfx}stations TEXT".to_owned(),
-                "Find station names containing or similar to the given name.".to_owned(),
+                "stations",
+                "wienerlinien",
+                "{cpfx}stations TEXT",
+                "Find station names containing or similar to the given name.",
             )
                 .build()
         ).await;


### PR DESCRIPTION
Thanks to Into<String>, string arguments can now take String and &str. Also
convert all usages of CommandDefinition::new() to CommandDefinitionBuilder.